### PR TITLE
Add 2020 magazine and Fall newsletter to site

### DIFF
--- a/_posts/2020-12-03-fall-newsletter.md
+++ b/_posts/2020-12-03-fall-newsletter.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Fall Newsletter
+author: StuyPulse
+link: https://drive.google.com/file/d/1QWr7S54ErlQ7w8_YIuX5Gs8SixZ8w1d5/view?usp=sharing
+---
+Check out our Fall Newsletter right [here](https://drive.google.com/file/d/1QWr7S54ErlQ7w8_YIuX5Gs8SixZ8w1d5/view?usp=sharing)!

--- a/index.html
+++ b/index.html
@@ -28,7 +28,11 @@ title: Team 694 - Stuyvesant High School's award winning FIRST Robotics team
         <h1>Latest News</h1>
         {% for post in site.posts | limit: 5 %}
             <div class="post-preview">
-                <h3><a href="{{ post.url }}">&raquo; {{ post.title }}</a></h3>
+                {% if post.link %}
+                    <h3><a href="{{ post.link }}">&raquo; {{ post.title }}</a></h3>
+                {% else %}
+                    <h3><a href="{{ post.url }}">&raquo; {{ post.title }}</a></h3>
+                {% endif %}
                 <div class="author-info">By {{post.author}} on {{ post.date | date: "%A, %B %d, %Y"}} <span class="comment-count"><a href="{{ post.url | append: '/#disqus_thread' }}">&nbsp;</a></span></div>
                 {{ post.content | split: "<!-- more -->" | first }}
                 {% if post.content contains "<!-- more -->" %}

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -7,6 +7,7 @@ title: Team Publications
 - [2014 Buckeye Regional](/downloads/teamdocs/pressreleases/OhioBuckeyeRegionalPressRelease.pdf)
 
 ## Magazines
+- [2020 Magazine](/downloads/teamdocs/magazines/2017Magazine.pdf)
 - [2017 Magazine](/downloads/teamdocs/magazines/2017Magazine.pdf)
 - [2016 Magazine](/downloads/teamdocs/magazines/2016Magazine.pdf)
 - [2012 Magazine](/downloads/teamdocs/magazines/2012Magazine.pdf)

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -7,7 +7,7 @@ title: Team Publications
 - [2014 Buckeye Regional](/downloads/teamdocs/pressreleases/OhioBuckeyeRegionalPressRelease.pdf)
 
 ## Magazines
-- [2020 Magazine](/downloads/teamdocs/magazines/2020Magazine.pdf)
+- [2020 Magazine](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/2020%20Magazine.pdf)
 - [2017 Magazine](/downloads/teamdocs/magazines/2017Magazine.pdf)
 - [2016 Magazine](/downloads/teamdocs/magazines/2016Magazine.pdf)
 - [2012 Magazine](/downloads/teamdocs/magazines/2012Magazine.pdf)

--- a/resources/publications/index.md
+++ b/resources/publications/index.md
@@ -7,7 +7,7 @@ title: Team Publications
 - [2014 Buckeye Regional](/downloads/teamdocs/pressreleases/OhioBuckeyeRegionalPressRelease.pdf)
 
 ## Magazines
-- [2020 Magazine](/downloads/teamdocs/magazines/2017Magazine.pdf)
+- [2020 Magazine](/downloads/teamdocs/magazines/2020Magazine.pdf)
 - [2017 Magazine](/downloads/teamdocs/magazines/2017Magazine.pdf)
 - [2016 Magazine](/downloads/teamdocs/magazines/2016Magazine.pdf)
 - [2012 Magazine](/downloads/teamdocs/magazines/2012Magazine.pdf)


### PR DESCRIPTION
Marketing wished to add two new documents, the 2020 magazine and the Fall newsletter, to the site.
Additionally, the newsletter redirect on the homepage has been fixed. Clicking on the title of the post will lead directly to the external document.

2020 magazine:
![image](https://user-images.githubusercontent.com/44385887/101112092-91b1e780-35aa-11eb-956b-d627ef144df5.png)

Fall newsletter:
![image](https://user-images.githubusercontent.com/44385887/101112114-9eced680-35aa-11eb-8dce-5fcfa8eb64fd.png)
(and on the homepage preview):
![image](https://user-images.githubusercontent.com/44385887/101112139-ac845c00-35aa-11eb-9899-724ee39a13c2.png)
