### PR TITLE
Update AIG logo on sponsors page

### DIFF
--- a/_data/sponsors/sponsors.yml
+++ b/_data/sponsors/sponsors.yml
@@ -6,7 +6,7 @@
   site: https://stuy-pa.org/
 - name: AIG
   site: https://www.aig.com/
-  logo: https://stuypulse.nyc3.digitaloceanspaces.com/site/sponsorships/img/aig.png
+  logo: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/sponsorships/img/aig.jpg
 - name: D.E. Shaw &amp; Co.
   logo: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/sponsorships/img/deshaw.gif
   site: http://www.deshaw.com/


### PR DESCRIPTION
Removed old non-transparent AIG logo and replaced with a transparent one.