### PR TITLE
Add FLL curriculum tab & PDF

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -41,6 +41,7 @@
                                 <ul class="dropdown-menu">
                                     <li><a href="/resources/">Documents &amp; Tutorials</a></li>
                                     <li><a href="/resources/publications/">Team Publications</a></li>
+                                    <li><a href="/resources/fll/">FLL Curriculum</a></li>
                                 </ul>
                             </li>
                             <li{% if page.url == '/calendar/' %} class="active"{% endif %}><a href="/calendar/">Calendar </a></li>

--- a/resources/fll/index.md
+++ b/resources/fll/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: FLL Curriculum
+---
+
+It all began in the spring of 2001 when Team 694 gave a presentation about instituting a robotics curriculum to interested teachers. Since then, we have helped inspire several schools to get involved in this spectacular program. In addition, Team 694 has been there to lend a helping hand by mentoring teams, especially I.S. 89 across the street whom we have mentored each year since 2002.
+
+Our involvement with FLL increased in December 2005 when the Manhattan Borough FLL Tournament was first held in our school. After last year's successful event, the great amount of experience gained was used to make this year's tournament even better. This year we also worked to upgrade our event to the standards of an official FIRST event. We also continued to send volunteers to help referee and queue teams at the NYC FLL tournament in Riverbank State Park as well as the Queens FLL Qualifier.
+
+As of 2019, we helped a variety of FLL Teams in Puerto Rico. More specifically, we aided in programming and their project presentations. These four teams were the ASJ Robotigers, Knight Hackers, The LEGO Builders and The Robogens.
+
+Recently, as of 2021, we've also devised our own FLL curriculum, designed specifically to help new teams and their mentors get a solid foundation in the basics of FLL robotics and its associated activities such as the FLL research project. A short introduction to the guide and the links to its resources can be found in [this PDF](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/FLL%20Curriculum%20Guide.pdf).

--- a/resources/index.md
+++ b/resources/index.md
@@ -3,6 +3,7 @@ layout: page
 title: Documents &amp; Tutorials
 description: StuyPulse has many resources available, including source code, documents, and tutorials on a variety of subjects.
 ---
+
 <div class="row">
 <div markdown="1" class="span8">
 ## Community
@@ -10,35 +11,49 @@ description: StuyPulse has many resources available, including source code, docu
 ### Resources
 
 #### [Open Source Software](https://github.com/StuyPulse)
+
 From our robot code to [this very website](/about/website/), everything we develop is open source. Check out our code on GitHub!
 
 #### [Stuy Splash Presentations](/community/projects/stuysplash/): [2012](/resources/stuysplash2012/) | [2013](/resources/stuysplash2013/) | [2014](/resources/stuysplash2014/) | [2015](/resources/stuysplash2015) | [2016](/resources/stuysplash2016) | [2017](/resources/stuysplash2017)
+
 [Stuy Splash](/community/projects/stuysplash/) is an intensive camp for FRC, covering everything from the foundation of your robot to the 0's and 1's that make it overweight.
 
 We have uploaded the presentations from the event, and they are available for download.
 
 #### [2012 Beta Seminar](/resources/2012betaseminar/)
+
 Video and resources from our 2012 Java, hardware, and Kinect beta seminar at Stuyvesant High School in December, 2011.
 
 #### [Driver Station Troubleshooting Guide](/downloads/docs/694%20Troubleshooting%20Guide.docx)
+
 A document published by our Software Engineering department in 2011 with solutions to common Driver Station issues.
 
 #### [Newbie FRC Games](/resources/newbiegames/)
+
 Documentation for all current and previous newbie games that we have made.
 
 #### [2021 Technical Binder [Elektra]](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/IR@H%20Presentation%20%281%29.pdf)
+
 #### [2020 Technical Binder [Edwin]](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/Technical%20Binder%202020.pdf)
+
 Our Technical Binders are available here.
+
+#### [FLL Curriculum](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/FLL%20Curriculum%20Guide.pdf)
+
+Our FLL curriculum guide, designed to help new teams and mentors.
 
 ### Tutorials
 
 #### [Fundraising](/resources/tutorials/fundraising/)
+
 Fundraising is a very important aspect of maintaining any FIRST Robotics team. Here is a guide to help you raise money.
 
 #### [How to Recruit](/resources/tutorials/recruitment/)
+
 A robotics team can sound very intimidating to a high school student, especially one who has no prior experience. However, the more people on a team, the more ideas and manpower the team has, and the better the robot will inevitably be. Here are a few ways to help your team grow and retain anywhere from over ten to over one hundred members.
 
 #### [Video Production](/resources/tutorials/videoproduction/)
+
 Creating videos for or about your team can be fun or can very tedious. Whether your experience are one or the other is dependent on how you carry out all the parts of the video production process.
 
 </div>
@@ -48,12 +63,15 @@ Creating videos for or about your team can be fun or can very tedious. Whether y
 ### Team Documents
 
 #### [Press Packet](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/sponsorships/2018SponsorshipPacket.pdf)
+
 Information and materials for potential [sponsors](/sponsors/).
 
 #### [Team Charter](https://charter.stuypulse.com)
+
 A formal description of our team's structure and government.
 
 #### [Operations Plan](/downloads/teamdocs/2016-2017OpsPlan.pdf)
+
 A statement of the long-term vision and goals of our team, and a plan for the year. The Operations Plan is prepared every summer by the incoming team leadership.
 
 #### [Branding Guide](/downloads/teamdocs/BrandingGuide2016-2017.pdf)
@@ -61,6 +79,8 @@ A statement of the long-term vision and goals of our team, and a plan for the ye
 ### For Members
 
 #### [Team Forms](/resources/forms/)
+
 Team members must fill out these forms in order to participate on the team.
+
 </div>
 </div>


### PR DESCRIPTION
We added an "FLL Curriculum" link to the "Resources" dropdown in the navbar.
| State | Image |
| ----------- | ----------- |
| Before | ![image](https://user-images.githubusercontent.com/50970130/139739584-a08af730-5dfb-48e5-9a0c-43fd478eebdb.png)|
| After | ![image](https://user-images.githubusercontent.com/50970130/139739609-d699832b-f6e0-4e91-964c-f723407e6fac.png)|

The hyperlinks in the following images now link to [this PDF](https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/pdf/FLL%20Curriculum%20Guide.pdf).

![image](https://user-images.githubusercontent.com/50970130/139739672-a2cf68c0-8ab8-47b6-a963-7b4681f99c09.png)
![image](https://user-images.githubusercontent.com/50970130/139740219-a974ed19-eeeb-45f3-9207-5e8e80a3e5bf.png)
