### PR TITLE
Update carousel script for flexibility

### DIFF
--- a/_data/carousel.yml
+++ b/_data/carousel.yml
@@ -3,6 +3,7 @@
 
 - img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/stuysplash2019.jpg
   caption-header: Check out Stuy Splash 2020! A YouTube playlist is available.
+  img-link: https://docs.google.com/document/d/1KNNnll-WENjqaWWsoex1aiRei_i4giS5dEUaoC-IV2c/edit
   read-more-link: https://docs.google.com/document/d/1KNNnll-WENjqaWWsoex1aiRei_i4giS5dEUaoC-IV2c/edit
 - img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/group-2020.jpg
   caption-header: Our 2020 season robot, Edwin!

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@ title: Team 694 - Stuyvesant High School's award winning FIRST Robotics team
     <div class="carousel-inner">
         {% for item in site.data.carousel | limit: 5 %}
             <div class="{% if forloop.first %}active {% endif %}item">
-                {% if item.read-more-link %}<a target="_blank" href="{{ item.read-more-link }}">{% endif %}
+                {% if item.img-link %}<a target="_blank" href="{{ item.img-link}}">{% endif %}
                 <img src="{{ item.img }}" alt="{{ item.caption-header }}">
-                {% if item.read-more-link %}</a>{% endif %}
+                {% if item.img-link %}</a>{% endif %}
                 <div class="carousel-caption">
                     <h4>{{ item.caption-header }}</h4>
                     <p>{{ item.caption-body }}</p>


### PR DESCRIPTION
Changed the interaction features of the carousel on the home page

- The image link and image read more link can now hold separate references for flexibility

Image on the carousel
<img width="963" alt="Screen Shot 2021-12-07 at 8 58 08 AM" src="https://user-images.githubusercontent.com/44385887/145043021-14d1e41b-78f5-4ea3-920a-04b765c5cc6b.png">

Clicking on the image can lead to a specified reference
<img width="1243" alt="Screen Shot 2021-12-07 at 8 58 17 AM" src="https://user-images.githubusercontent.com/44385887/145043142-6854e74a-3e39-443f-b3b5-ca2f26a80341.png">

Clicking on the read-more link at the bottom can lead to different specified reference
<img width="1232" alt="Screen Shot 2021-12-07 at 8 58 25 AM" src="https://user-images.githubusercontent.com/44385887/145043243-f09b7d83-0e19-4cb0-b771-f60026856c47.png">


