### PR TITLE
Add temporary 2021 StuySplash carousel slide

### DIFF
--- a/_data/carousel.yml
+++ b/_data/carousel.yml
@@ -1,10 +1,10 @@
 # Carousel items on front page
 # There must be exactly 5 items
 
-- img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/stuysplash2019.jpg
-  caption-header: Check out Stuy Splash 2020! A YouTube playlist is available.
-  img-link: https://docs.google.com/document/d/1KNNnll-WENjqaWWsoex1aiRei_i4giS5dEUaoC-IV2c/edit
-  read-more-link: https://docs.google.com/document/d/1KNNnll-WENjqaWWsoex1aiRei_i4giS5dEUaoC-IV2c/edit
+- img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/stuysplash2021.jpg
+  caption-header: Check out Stuy Splash 2021!
+  img-link: https://drive.google.com/drive/folders/1nrTNPP_3gJfcmTTOtQU3lFotwvUJDjks?usp=sharing
+  read-more-link: https://docs.google.com/document/d/1AJYNXKlTIg2xEQEvYFWsogLXYhHoj8KnY0LloDK9eEM/edit
 - img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/group-2020.jpg
   caption-header: Our 2020 season robot, Edwin!
 - img: https://stuypulse.nyc3.cdn.digitaloceanspaces.com/site/img/carousel/palmetto-2020.JPG


### PR DESCRIPTION
Added a temporary carousel slide for 2021 StuySplash while all the presentations, descriptions, and videos are being gathered

Temporary carousel slide:
<img width="1090" alt="Screen Shot 2021-12-09 at 6 24 49 PM" src="https://user-images.githubusercontent.com/44385887/145491609-caf61106-473e-4b96-b928-5980247478ca.png">

Clicking on the image will lead to the drive of the collected presentations at the moment:
<img width="1127" alt="Screen Shot 2021-12-09 at 6 24 59 PM" src="https://user-images.githubusercontent.com/44385887/145491663-0e3800d3-955a-4600-b965-d536621fab41.png">

Clicking on the "read more" button will lead to the 2021 StuySplash schedule:
<img width="1303" alt="Screen Shot 2021-12-09 at 6 25 12 PM" src="https://user-images.githubusercontent.com/44385887/145491711-a27d0f83-7f6d-4891-9820-253328e180fc.png">


